### PR TITLE
Add link to Bosch BMI160

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # BMI160 sensor API
+For the Accelerometer and Gyroscope 
+ https://www.bosch-sensortec.com/bst/products/all_products/bmi160 
+
 ## Introduction
 This package contains the Bosch Sensortec's BMI160 sensor driver (sensor API)
 


### PR DESCRIPTION
Add a link to the specifications page on the Bosch site.

PS Seems like this README.md file has too much code in it.