### PR TITLE
Implemented multi-interrupt channel support

### DIFF
--- a/bmi160.c
+++ b/bmi160.c
@@ -4502,7 +4502,7 @@ static int8_t config_int_out_ctrl(const struct bmi160_int_settg *int_config, con
 		const struct bmi160_int_pin_settg *intr_pin_sett = &(int_config->int_pin_settg);
 
 		/* Configuring channel 1 */
-		if (int_config->int_channel == BMI160_INT_CHANNEL_1) {
+		if ((int_config->int_channel == BMI160_INT_CHANNEL_1) || (int_config->int_channel == BMI160_INT_CHANNEL_BOTH)) {
 
 			/* Output enable */
 			temp = data & ~BMI160_INT1_OUTPUT_EN_MASK;
@@ -4519,10 +4519,12 @@ static int8_t config_int_out_ctrl(const struct bmi160_int_settg *int_config, con
 			/* edge control */
 			temp = data & ~BMI160_INT1_EDGE_CTRL_MASK;
 			data = temp | ((intr_pin_sett->edge_ctrl) & BMI160_INT1_EDGE_CTRL_MASK);
+		} 
+       
+	    /* Configuring channel 2 */
+        if ((int_config->int_channel == BMI160_INT_CHANNEL_2) || (int_config->int_channel == BMI_INT_CHANNEL_BOTH)) {
 
-		} else {
-			/* Configuring channel 2 */
-			/* Output enable */
+          /* Output enable */
 			temp = data & ~BMI160_INT2_OUTPUT_EN_MASK;
 			data = temp | ((intr_pin_sett->output_en << 7) & BMI160_INT2_OUTPUT_EN_MASK);
 

--- a/bmi160.c
+++ b/bmi160.c
@@ -4498,21 +4498,23 @@ static int8_t config_int_out_ctrl(const struct bmi160_int_settg *int_config, con
 	rslt = bmi160_get_regs(BMI160_INT_OUT_CTRL_ADDR, &data, 1, dev);
 
 	if (rslt == BMI160_OK) {
-        /* guard statement to ensure a valid pin channel is configured */
-        switch (int_config->int_channel){
-            case BMI160_INT_CHANNEL_1:
-            case BMI160_INT_CHANNEL_2:
-            case BMI160_INT_CHANNEL_BOTH:
-              break;
-            default: // invalid pin channel
-              return BMI160_E_DEV_NOT_FOUND;
-        }
+        
+		/* guard statement to ensure a valid pin channel is configured */
+		switch (int_config->int_channel) {
+			case BMI160_INT_CHANNEL_1:
+			case BMI160_INT_CHANNEL_2:
+			case BMI160_INT_CHANNEL_BOTH:
+				break;
+			default: // invalid pin channel
+				return BMI160_E_DEV_NOT_FOUND;
+		}
 
 		/* updating the interrupt pin structure to local structure */
 		const struct bmi160_int_pin_settg *intr_pin_sett = &(int_config->int_pin_settg);
 
 		/* Configuring channel 1 */
-		if ((int_config->int_channel == BMI160_INT_CHANNEL_1) || (int_config->int_channel == BMI160_INT_CHANNEL_BOTH)) {
+		if ((int_config->int_channel == BMI160_INT_CHANNEL_1) ||
+			(int_config->int_channel == BMI160_INT_CHANNEL_BOTH)) {
 
 			/* Output enable */
 			temp = data & ~BMI160_INT1_OUTPUT_EN_MASK;
@@ -4531,10 +4533,11 @@ static int8_t config_int_out_ctrl(const struct bmi160_int_settg *int_config, con
 			data = temp | ((intr_pin_sett->edge_ctrl) & BMI160_INT1_EDGE_CTRL_MASK);
 		} 
        
-	    /* Configuring channel 2 */
-        if ((int_config->int_channel == BMI160_INT_CHANNEL_2) || (int_config->int_channel == BMI160_INT_CHANNEL_BOTH)) {
+		/* Configuring channel 2 */
+		if ((int_config->int_channel == BMI160_INT_CHANNEL_2) ||
+			(int_config->int_channel == BMI160_INT_CHANNEL_BOTH)) {
 
-          /* Output enable */
+			/* Output enable */
 			temp = data & ~BMI160_INT2_OUTPUT_EN_MASK;
 			data = temp | ((intr_pin_sett->output_en << 7) & BMI160_INT2_OUTPUT_EN_MASK);
 

--- a/bmi160.c
+++ b/bmi160.c
@@ -4498,6 +4498,16 @@ static int8_t config_int_out_ctrl(const struct bmi160_int_settg *int_config, con
 	rslt = bmi160_get_regs(BMI160_INT_OUT_CTRL_ADDR, &data, 1, dev);
 
 	if (rslt == BMI160_OK) {
+        /* guard statement to ensure a valid pin channel is configured */
+        switch (int_config->int_channel){
+            case BMI160_INT_CHANNEL_1:
+            case BMI160_INT_CHANNEL_2:
+            case BMI160_INT_CHANNEL_BOTH:
+              break;
+            default: // invalid pin channel
+              return BMI160_E_DEV_NOT_FOUND;
+        }
+
 		/* updating the interrupt pin structure to local structure */
 		const struct bmi160_int_pin_settg *intr_pin_sett = &(int_config->int_pin_settg);
 

--- a/bmi160.c
+++ b/bmi160.c
@@ -4532,7 +4532,7 @@ static int8_t config_int_out_ctrl(const struct bmi160_int_settg *int_config, con
 		} 
        
 	    /* Configuring channel 2 */
-        if ((int_config->int_channel == BMI160_INT_CHANNEL_2) || (int_config->int_channel == BMI_INT_CHANNEL_BOTH)) {
+        if ((int_config->int_channel == BMI160_INT_CHANNEL_2) || (int_config->int_channel == BMI160_INT_CHANNEL_BOTH)) {
 
           /* Output enable */
 			temp = data & ~BMI160_INT2_OUTPUT_EN_MASK;


### PR DESCRIPTION
Was stuck for a while during development for the BMI160 sensor due to using the `BMI160_INT_CHANNEL_BOTH` define which can be found in: https://github.com/BoschSensortec/BMI160_driver/blob/44f0df94d6b000a821afd7ed31c432bc677cd723/bmi160_defs.h#L1004

The define is there, however when configuring the sensor, the code for configuring both interrupt channels is lacking in the driver library. Since the current library implementation defaults to configuring interrupt channel 2 for every value other than `BMI160_INT_CHANNEL_1`, it will configure interrupt channel 2 - not both - when setting int_channel to `BMI160_INT_CHANNEL_BOTH`. This is very misleading.

This PR implements support for both interrupt channels for the sensor, and it implements a guard statement to return an error code in case an invalid configuration is provided instead of defaulting to interrupt channel 2.

After testing my fork of the library with these changes on our device I get the following value in the INT_OUT_CTRL register (0x53): 
```
BMI160_INT_OUT_CTRL_ADDR  (0x53) :: 0x88
```

This means that the output enable for both interrupt channel 1 and 2 is set to enabled. For more details on this, see the [BMI160 datasheet](https://www.mouser.com/ds/2/783/BST-BMI160-DS000-07-786474.pdf) on page 63.