### PR TITLE
Make BMX160 compatible, define chip ID only when not defined

### DIFF
--- a/bmi160_defs.h
+++ b/bmi160_defs.h
@@ -358,7 +358,9 @@
 #define BMI160_W_ACCEl_SELF_TEST_FAIL             INT8_C(2)
 
 /** BMI160 unique chip identifier */
+#ifndef BMI160_CHIP_ID
 #define BMI160_CHIP_ID                            UINT8_C(0xD1)
+#endif
 
 /** Soft reset command */
 #define BMI160_SOFT_RESET_CMD                     UINT8_C(0xb6)


### PR DESCRIPTION
This BMI160 driver is also needed for BMX160 products from Bosch. Unfortunately, this driver hardcodes the chip ID. Instead, this PR adds a one-line fix using `ifndef` for the BMI160_CHIP_ID definition.

This enables better experience for developers and makes the library work with both BMI160 and BMX160 out-of-the-box.

Signed-off-by: Dimitar Tomov <dimi@edgeimpulse.com>